### PR TITLE
added getItemMetadata method to collection adapter

### DIFF
--- a/dist/slickback.full.js
+++ b/dist/slickback.full.js
@@ -529,6 +529,13 @@
   var getItem = function(i) {
     return this.models[i];
   };
+  
+  var getItemMetadata : function(row) {
+      var model = this.models[row];
+      if (model.getItemMetadata) {
+          return model.getItemMetadata();
+      }
+  };
 
   /**
    * Adapts a collection that stores its models in a model array
@@ -536,7 +543,8 @@
    */
   exportNamespace.CollectionAdaptorMixin = {
     getLength: getLength,
-    getItem:   getItem
+    getItem:   getItem,
+    getItemMetadata: getItemMetadata
   };
 
 }).call(this);


### PR DESCRIPTION
Allows for providing rowlevel metadata to the grid. https://github.com/mleibman/SlickGrid/wiki/Providing-data-to-the-grid
