### PR TITLE
Fix to speed up pagination with backbone 1.0

### DIFF
--- a/dist/slickback.full.js
+++ b/dist/slickback.full.js
@@ -445,7 +445,7 @@
     }
     // NOTE: this notification will happen again on reset
     this.onPagingInfoChanged.notify(this.getPagingInfo());
-    this.fetchWithPagination();
+    this.fetchWithPagination({reset: true});
   };
 
   /**


### PR DESCRIPTION
Backbone 1.0 has an optimized set implementation. Without passing in reset option, fetchWithPagination will invoke fetch in backbone 1.0 forcing it to do set on the collection instead of reset. Invoking set for every pagination will take extremely long, due the nature of set optimization logic. Hence pass in reset to force the call to reset
